### PR TITLE
Address a handful of maybe-uninitialized warnings

### DIFF
--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -752,8 +752,8 @@ void Alg_event_list::set_start_time(Alg_event *event, double t)
     // For Alg_track, change the time and move the event to the right place
     // For Alg_seq, find the track and do the update there
 
-    long index, i;
-    Alg_track_ptr track_ptr;
+    long index = 0;
+    Alg_track_ptr track_ptr = nullptr;
     if (type == 'e') { // this is an Alg_event_list
         // make sure the owner has not changed its event set
         assert(events_owner &&
@@ -773,7 +773,7 @@ void Alg_event_list::set_start_time(Alg_event *event, double t)
         }
     } else { // type == 's', an Alg_seq
         Alg_seq_ptr seq = (Alg_seq_ptr) this;
-        for (i = 0; i < seq->tracks(); i++) {
+        for (int i = 0; i < seq->tracks(); i++) {
             track_ptr = seq->track(i);
             // if you implemented binary search, you could call it
             // instead of this loop too.
@@ -1897,7 +1897,7 @@ void Alg_track::paste(double t, Alg_event_list *seq)
     assert(get_type() == 't');
     // seq can be an Alg_event_list, an Alg_track, or an Alg_seq
     // if it is an Alg_event_list, units_are_seconds must match
-    bool prev_units_are_seconds;
+    bool prev_units_are_seconds = false;
     if (seq->get_type() == 'e') {
         assert(seq->get_owner()->get_units_are_seconds() == units_are_seconds);
     } else { // make it match

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -155,7 +155,7 @@ bool Alg_reader::parse()
     while (line_parser_flag) {
         bool time_flag = false;
         bool next_flag = false;
-        double next;
+        double next = 0.0;
         bool voice_flag = false;
         bool loud_flag = false;
         bool dur_flag = false;


### PR DESCRIPTION
This fixes some `maybe-uninitialized` warnings by giving the offending variables default values.

TL;DR none of these warnings actually indicate real problems. Every single place these variables are read are code paths in which the variables are initialized.

Regardless, LMMS is using this library as a dependency and compiles with `-Werror`, which means we either have to disable these compiler warnings or resolve them. Our current strategy is to build just the portsmf files with `-Wno-error=maybe-uninitialized` and that seems to work just fine.

All these "fixes" predate the "just disable the warnings" solution. I am presenting these here as options with no expectations; I am happy to discard some or all of these. At the very least this PR can serve as documentation for the next person to complain about this same thing.

## `i` in `Alg_event_list::set_start_time()`

This variable is only ever used in a single `for` loop and is passed into `Alg_seq::track(int)`, so I moved the declaration to the `for` loop and made its type `int` as well.

## `index` in `Alg_event_list::set_start_time()`

The only place where `index` could be read while uninitialized is past an `assert(false)`, but the compiler complains anyway. I gave `index` a default value of `0`.

## `track_ptr` in `Alg_event_list::set_start_time()`

Same as the previous, the code will `assert(false)` before ever reading from an uninitialized `track_ptr`. I gave it a default value of `nullptr`.

## `prev_units_are_seconds` in `Alg_track::paste()`

`prev_units_are_seconds` is only ever read from if the source sequence is not of type `Alg_event_list`, and is only ever uninitialized in code paths where the source sequence is of type `Alg_event_list`. Therefore, it won't ever be read while uninitialized... yet the compiler complains anyway. I gave `prev_units_are_seconds` a default value of `false`.

## `next` in `Alg_reader::parse()`

`next` is only ever read from if `next_flag` is `true`, which is only the case in a single code path in which `next` is also set. Therefore, it won't ever be read while uninitialized... you know where this is going. I gave `next` a default value of `0.0`.