### PR TITLE
Use more accurate and descriptive integer types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
    OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(-Wall -Wextra -pedantic)
+  add_compile_options(-Wall -Wextra -pedantic -Wno-deprecated-declarations)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(/W4)
+  add_compile_options(/W4 /D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 option(BUILD_SHARED_LIBS "Build dynamic library" ON)

--- a/apps/allegroconvert.cpp
+++ b/apps/allegroconvert.cpp
@@ -71,8 +71,7 @@ int main(int argc, char *argv[])
     bool tempo_flag = false;
     char *ext = nullptr;
 
-    int i = 1;
-    while (i < argc - 1) {
+    for (int i = 1; i < argc - 1; i++) {
         if (argv[i][0] != '-') { print_help(); }
         if (argv[i][1] == 'm') { midifile = true; }
         else if (argv[i][1] == 'a') { allegrofile = true; }
@@ -84,12 +83,11 @@ int main(int argc, char *argv[])
         } else if (argv[i][1] == 'f') {
             flatten_flag = true;
         } else { print_help(); }
-        i++;
     }
     // Do not use both -t and -f:
     if (tempo_flag & flatten_flag) { print_help(); }
 
-    int len = strlen(filename);
+    size_t len = strlen(filename);
     if (!midifile && !allegrofile) {
         if (len < 4) { print_help(); } // no extension, need -m or -a
         ext = filename + len - 4;
@@ -123,11 +121,11 @@ int main(int argc, char *argv[])
         seq->smf_write(outfilename);
     }
 
-    int events = 0;
-    for (i = 0; i < seq->track_list.length(); i++) {
+    size_t events = 0;
+    for (size_t i = 0; i < seq->track_list.length(); i++) {
         events += seq->track_list[i].length();
     }
-    printf("%ld tracks, %d events\n", seq->track_list.length(), events);
+    printf("%ld tracks, %zu events\n", seq->track_list.length(), events);
     printf("wrote %s\n", outfilename);
     
     /* DELETE THE DATA */

--- a/apps/allegroplay.cpp
+++ b/apps/allegroplay.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     }
 
     if (!midifile && !allegrofile) {
-        int len = strlen(filename);
+        size_t len = strlen(filename);
         if (len < 4) { print_help(); } // no extension, need -m or -a
         char *ext = filename + len - 4;
         if (strcmp(ext, ".mid") == 0) { midifile = true; }
@@ -63,12 +63,12 @@ int main(int argc, char *argv[])
     }
     Alg_seq seq(filename, midifile);
 
-    int events = 0;
-    for (i = 0; i < seq.tracks(); i++) {
+    size_t events = 0;
+    for (size_t j = 0; j < seq.tracks(); j++) {
         events += seq.track(i)->length();
     }
     if (interactive) {
-        printf("%d tracks, %d events\n", seq.tracks(), events);
+        printf("%zu tracks, %zu events\n", seq.tracks(), events);
     }
     /* PLAY THE FILE VIA MIDI: */
     if (interactive) {

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -34,7 +34,7 @@
 //! UNSERIALIZATION:
 //!
 //! The Alg_track class has a static member:
-//!     unserialize(char *buffer, long len)
+//!     unserialize(char *buffer, size_t len)
 //! that will unserialize anything -- an Alg_track or an Alg_seq.
 //! No other function should be called from outside the library.
 //! Internal unserialize functions are:
@@ -85,7 +85,7 @@ public:
     //! that Alg_atoms will not be reported as memory leaks by automation
     //! that doesn't know better. -RBD
     virtual ~Alg_atoms() {
-        for (int i = 0; i < len; i++) {
+        for (size_t i = 0; i < len; i++) {
             delete atoms[i];
         }
         delete[] atoms;
@@ -95,8 +95,8 @@ public:
     //! insert/lookup attribute by name (without prefixed type)
     Alg_attribute insert_string(const char *name);
 private:
-    long maxlen;
-    long len;
+    size_t maxlen;
+    size_t len;
     Alg_attribute *atoms;
 
     //! Insert an Attribute not in table after moving attr to heap
@@ -361,10 +361,10 @@ public:
 //! A sequence of Alg_event objects
 class Alg_events {
 private:
-    long maxlen;
+    size_t maxlen;
     void expand();
 protected:
-    long len;
+    size_t len;
     Alg_event **events; //!< events is array of pointers
 public:
     //! sometimes, it is nice to have the time of the last note-off.
@@ -377,9 +377,9 @@ public:
     //! initially false, in_use can be used to mark "do not delete". If an
     //! Alg_events instance is deleted while "in_use", an assertion will fail.
     bool in_use;
-    virtual int length() { return len; }
-    Alg_event *&operator[](int i) {
-        assert(i >= 0 && i < len);
+    virtual size_t length() { return len; }
+    Alg_event *&operator[](size_t i) {
+        assert(i < len);
         return events[i];
     }
     Alg_events() {
@@ -391,14 +391,14 @@ public:
     //! destructor deletes the events array, but not the
     //! events themselves
     virtual ~Alg_events();
-    void set_events(Alg_event **e, long l, long m) {
+    void set_events(Alg_event **e, size_t l, size_t m) {
         delete[] events;
         events = e; len = l; maxlen = m;
     }
     //! for use by Alg_track and Alg_seq
     void insert(Alg_event *event);
     void append(Alg_event *event);
-    Alg_event *uninsert(long index);
+    Alg_event *uninsert(size_t index);
 };
 
 class Alg_track;
@@ -439,7 +439,7 @@ public:
     //! When applied to an Alg_seq, events are enumerated track
     //! by track with increasing indices. This operation is not
     //! particularly fast on an Alg_seq.
-    virtual Alg_event *&operator[](int i);
+    virtual Alg_event *&operator[](size_t i);
     Alg_event_list() { sequence_number = 0;
         beat_dur = 0.0; real_dur = 0.0; events_owner = nullptr; type = 'e'; }
     Alg_event_list(Alg_track *owner);
@@ -495,13 +495,13 @@ public:
 //! A list of \ref Alg_beat objects used in \ref Alg_seq
 class Alg_beats {
 private:
-    long maxlen;
+    size_t maxlen;
     void expand();
 public:
-    long len;
+    size_t len;
     Alg_beat *beats;
-    Alg_beat &operator[](int i) {
-        assert(i >= 0 && i < len);
+    Alg_beat &operator[](size_t i) {
+        assert(i < len);
         return beats[i];
     }
     Alg_beats() {
@@ -513,7 +513,7 @@ public:
         len = 1;
     }
     ~Alg_beats() { delete[] beats; }
-    void insert(long i, Alg_beat *beat);
+    void insert(size_t i, Alg_beat *beat);
 };
 
 
@@ -532,10 +532,10 @@ public:
         refcount = 0;
     }
     Alg_time_map(Alg_time_map *map); //!< copy constructor
-    long length() { return beats.len; }
+    size_t length() { return beats.len; }
     void show();
-    long locate_time(double time);
-    long locate_beat(double beat);
+    size_t locate_time(double time);
+    size_t locate_beat(double beat);
     double beat_to_time(double beat);
     double time_to_beat(double time);
     //! Time map manipulations: it is prefered to call the corresponding
@@ -578,7 +578,7 @@ class Serial_buffer {
   protected:
     char *buffer;
     char *ptr;
-    long len;
+    size_t len;
   public:
     Serial_buffer() {
         buffer = nullptr;
@@ -587,8 +587,8 @@ class Serial_buffer {
     }
     virtual ~Serial_buffer() = default;
 
-    long get_posn() { return static_cast<long>(ptr - buffer); }
-    long get_len() { return len; }
+    size_t get_posn() { return static_cast<size_t>(ptr - buffer); }
+    size_t get_len() { return len; }
 };
 
 
@@ -605,7 +605,7 @@ public:
     //! Prepare to read n bytes from buf. The caller must manage buf: it is
     //! valid until reading is finished, and it is caller's responsibility
     //! to free buf when it is no longer needed.
-    void init_for_read(void *buf, long n) {
+    void init_for_read(void *buf, size_t n) {
         buffer = static_cast<char *>(buf);
         ptr = static_cast<char *>(buf);
         len = n;
@@ -651,13 +651,13 @@ class Serial_write_buffer: public Serial_buffer {
     ~Serial_write_buffer() override { delete[] buffer; }
     void init_for_write() { ptr = buffer; }
     //! Writes an int32_t at a given offset
-    void store_int32(long offset, int32_t value) {
-        assert(offset <= static_cast<long>(get_posn() - sizeof(int32_t)));
+    void store_int32(size_t offset, int32_t value) {
+        assert(offset <= static_cast<size_t>(get_posn() - sizeof(int32_t)));
         *reinterpret_cast<int32_t *>(buffer + offset) = value;
     }
     [[deprecated("Use store_int32() instead")]]
-    void store_long(long offset, long value) { store_int32(offset, static_cast<int32_t>(value)); }
-    void check_buffer(long needed);
+    void store_long(size_t offset, long value) { store_int32(offset, static_cast<int32_t>(value)); }
+    void check_buffer(size_t needed);
     void set_string(const char *s) {
         [[maybe_unused]] char *fence = buffer + len;
         assert(ptr < fence);
@@ -668,7 +668,7 @@ class Serial_write_buffer: public Serial_buffer {
         pad();
     }
     void set_int32(int32_t v) {
-        *(reinterpret_cast<long *>(ptr)) = v;
+        *(reinterpret_cast<int32_t *>(ptr)) = v;
         ptr += sizeof(int32_t);
     }
     void set_double(double v) {
@@ -683,7 +683,7 @@ class Serial_write_buffer: public Serial_buffer {
     void pad() {
         while (reinterpret_cast<uintptr_t>(ptr) & 7) { set_char(0); }
     }
-    void *to_heap(long *len) {
+    void *to_heap(size_t *len) {
         *len = get_posn();
         char *newbuf = new char[*len];
         memcpy(newbuf, buffer, *len);
@@ -710,8 +710,8 @@ protected:
 public:
     void serialize_track();
     void unserialize_track();
-    Alg_event *&operator[](int i) override {
-        assert(i >= 0 && i < len);
+    Alg_event *&operator[](size_t i) override {
+        assert(i < len);
         return events[i];
     }
     Alg_track() { units_are_seconds = false; time_map = nullptr;
@@ -735,12 +735,12 @@ public:
     //! Returns a buffer containing a serialization of the
     //! file.  It will be an ASCII representation unless text is true.
     //! *buffer gets a newly allocated buffer pointer. The caller must free it.
-    //! *len gets the length of the serialized track
-    virtual void serialize(void **buffer, long *bytes);
+    //! *bytes gets the length of the serialized track
+    virtual void serialize(void **buffer, size_t *bytes);
 
     //! Try to read from a memory buffer.  Automatically guess
     //! whether it's MIDI or text.
-    static Alg_track *unserialize(void *buffer, long len);
+    static Alg_track *unserialize(void *buffer, size_t len);
 
     //! If the track is really an Alg_seq and you need to access an
     //! Alg_seq method, coerce to an Alg_seq with this function:
@@ -911,23 +911,23 @@ public:
 //! until the next time_sig.
 class Alg_time_sigs {
 private:
-    long maxlen;
+    size_t maxlen;
     void expand(); //!< make more space
-    long len;
+    size_t len;
     Alg_time_sig *time_sigs;
 public:
     Alg_time_sigs() {
         maxlen = len = 0;
         time_sigs = nullptr;
     }
-    Alg_time_sig &operator[](int i) { //!< fetch a time signature
-        assert(i >= 0 && i < len);
+    Alg_time_sig &operator[](size_t i) { //!< fetch a time signature
+        assert(i < len);
         return time_sigs[i];
     }
     ~Alg_time_sigs() { delete[] time_sigs; }
     void show();
-    long length() { return len; }
-    int find_beat(double beat);
+    size_t length() { return len; }
+    size_t find_beat(double beat);
     //! get the number of beats per measure starting at beat
     double get_bar_len(double beat);
     void insert(double beat, double num, double den, bool force = false);
@@ -943,17 +943,17 @@ public:
 //! A sequence of Alg_events objects
 class Alg_tracks {
 private:
-    long maxlen;
+    size_t maxlen;
     void expand();
     void expand_to(int new_max);
-    long len;
+    size_t len;
 public:
     Alg_track **tracks; //!< tracks is array of pointers
-    Alg_track &operator[](int i) {
-        assert(i >= 0 && i < len);
+    Alg_track &operator[](size_t i) {
+        assert(i < len);
         return *tracks[i];
     }
-    long length() { return len; }
+    size_t length() { return len; }
     Alg_tracks() {
         maxlen = len = 0;
         tracks = nullptr;
@@ -961,7 +961,7 @@ public:
     ~Alg_tracks();
     //! Append a track to tracks. This Alg_tracks becomes the owner of track.
     void append(Alg_track *track);
-    void add_track(int track_num, Alg_time_map *time_map, bool seconds);
+    void add_track(size_t track_num, Alg_time_map *time_map, bool seconds);
     void reset();
     void set_in_use(bool flag); //!< handy to set in_use flag on all tracks
 };
@@ -984,7 +984,7 @@ typedef enum {
 struct Alg_pending_event {
     void *cookie; //!< client-provided sequence identifier
     Alg_events *events; //!< the array of events
-    long index; //!< offset of this event
+    size_t index; //!< offset of this event
     bool note_on; //!< is this a note-on or a note-off (if applicable)?
     double offset; //!< time offset for events
     double time; //!< time for this event
@@ -993,23 +993,23 @@ struct Alg_pending_event {
 
 class Alg_iterator {
 private:
-    long maxlen;
+    size_t maxlen;
     void expand();
     void expand_to(int new_max);
-    long len;
+    size_t len;
     Alg_seq *seq;
     Alg_pending_event *pending_events;
     //! the next four fields are mainly for request_note_off()
     Alg_events *events_ptr; //!< remembers events containing current event
-    long index; //!< remembers index of current event
+    size_t index; //!< remembers index of current event
     void *cookie; //!< remembers the cookie associated with next event
     double offset;
     void show();
     bool earlier(int i, int j);
-    void insert(Alg_events *events, long index, bool note_on,
+    void insert(Alg_events *events, size_t index, bool note_on,
                 void *cookie, double offset);
     //! returns the info on the next pending event in the priority queue
-    bool remove_next(Alg_events *&events, long &index, bool &note_on,
+    bool remove_next(Alg_events *&events, size_t &index, bool &note_on,
                      void *&cookie, double &offset, double &time);
 public:
     ~Alg_iterator() { delete[] pending_events; }
@@ -1095,7 +1095,7 @@ public:
     Alg_seq(const char *filename, bool smf, double *offset_ptr = nullptr);
     ~Alg_seq() override;
     int get_read_error() { return error; }
-    void serialize(void **buffer, long *bytes) override;
+    void serialize(void **buffer, size_t *bytes) override;
     void copy_time_sigs_to(Alg_seq *dest); //!< a utility function
     void set_time_map(Alg_time_map *map) override;
 
@@ -1112,41 +1112,41 @@ public:
     bool smf_write(const char *filename);
 
     //! Returns the number of tracks
-    int tracks();
+    size_t tracks();
 
     //! create a track
-    void add_track(int track_num) {
+    void add_track(size_t track_num) {
         track_list.add_track(track_num, get_time_map(), units_are_seconds);
     }
 
     //! Return a particular track. This Alg_seq owns the track, so the
     //! caller must not delete the result.
-    Alg_track *track(int);
+    Alg_track *track(size_t);
 
-    Alg_event *&operator[](int i) override;
+    Alg_event *&operator[](size_t i) override;
 
     void convert_to_seconds() override;
     void convert_to_beats() override;
 
-    Alg_track *cut_from_track(int track_num, double start, double dur,
+    Alg_track *cut_from_track(size_t track_num, double start, double dur,
                                  bool all);
     Alg_seq *cut(double t, double len, bool all) override;
-    void insert_silence_in_track(int track_num, double t, double len);
+    void insert_silence_in_track(size_t track_num, double t, double len);
     void insert_silence(double t, double len) override;
-    Alg_track *copy_track(int track_num, double t, double len, bool all);
+    Alg_track *copy_track(size_t track_num, double t, double len, bool all);
     Alg_seq *copy(double start, double len, bool all) override;
     void paste(double start, Alg_seq *seq);
     void clear(double t, double len, bool all) override;
     void merge(double t, Alg_event_list *seq) override;
     void silence(double t, double len, bool all) override;
-    void clear_track(int track_num, double start, double len, bool all);
-    void silence_track(int track_num, double start, double len, bool all);
-    Alg_event_list *find_in_track(int track_num, double t, double len,
+    void clear_track(size_t track_num, double start, double len, bool all);
+    void silence_track(size_t track_num, double start, double len, bool all);
+    Alg_event_list *find_in_track(size_t track_num, double t, double len,
                                      bool all, long channel_mask,
                                      long event_type_mask);
 
     //! find index of first score event after time
-    long seek_time(double time, int track_num);
+    size_t seek_time(double time, size_t track_num);
     bool insert_beat(double time, double beat);
     //! return the time of the beat nearest to time, also returns beat
     //! number through beat. This will correspond to an integer number
@@ -1162,7 +1162,7 @@ public:
     bool stretch_region(double b0, double b1, double dur);
     //! add_event takes a pointer to an event on the heap. The event is not
     //! copied, and this Alg_seq becomes the owner and freer of the event.
-    void add_event(Alg_event *event, int track_num);
+    void add_event(Alg_event *event, size_t track_num);
     void add(Alg_event */*event*/) override { assert(false); } //!< call add_event instead
     //! get the tempo starting at beat
     double get_tempo(double beat);
@@ -1173,7 +1173,7 @@ public:
     void set_time_sig(double beat, double num, double den);
     void beat_to_measure(double beat, long *measure, double *m_beat,
                          double *num, double *den);
-    //! void set_events(Alg_event **events, long len, long max);
+    //! void set_events(Alg_event **events, size_t len, size_t max);
     void merge_tracks();    //!< move all track data into one track
     void set_in_use(bool flag) override; //!< set in_use flag on all tracks
 };

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -137,7 +137,7 @@ public:
     void copy(Alg_parameter *); //!< copy from another parameter
     char attr_type() { return alg_attr_type(attr); }
     const char *attr_name() { return alg_attr_name(attr); }
-    void set_attr(Alg_attribute a) { attr = a; }
+    void set_attr(Alg_attribute attribute) { attr = attribute; }
     void show();
 };
 
@@ -611,7 +611,7 @@ public:
         len = n;
     }
     char get_char() { return *ptr++; }
-    void unget_chars(int n) { ptr -= n; } // undo n get_char() calls
+    void unget_chars(size_t n) { ptr -= n; } //!< Undo n get_char() calls
     int32_t get_int32() {
         const int32_t i = *(reinterpret_cast<int32_t *>(ptr));
         ptr += sizeof(int32_t);
@@ -635,7 +635,7 @@ public:
         get_pad();
         return s;
     }
-    void check_input_buffer(size_t needed) {
+    void check_input_buffer([[maybe_unused]] size_t needed) {
         assert(get_posn() + needed <= len);
     }
 };
@@ -945,7 +945,7 @@ class Alg_tracks {
 private:
     size_t maxlen;
     void expand();
-    void expand_to(int new_max);
+    void expand_to(size_t new_max);
     size_t len;
 public:
     Alg_track **tracks; //!< tracks is array of pointers
@@ -995,7 +995,7 @@ class Alg_iterator {
 private:
     size_t maxlen;
     void expand();
-    void expand_to(int new_max);
+    void expand_to(size_t new_max);
     size_t len;
     Alg_seq *seq;
     Alg_pending_event *pending_events;

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -1068,7 +1068,7 @@ protected:
     void serialize_seq();
     Alg_error error; //!< error code set by file readers
     //! an internal function used for writing Allegro track names
-    Alg_event *write_track_name(std::ostream &file, int n,
+    Alg_event *write_track_name(std::ostream &file, size_t n,
                                    Alg_events &events);
 public:
     int channel_offset_per_track; //!< used to encode track_num into channel

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -635,7 +635,7 @@ public:
         get_pad();
         return s;
     }
-    void check_input_buffer(long needed) {
+    void check_input_buffer(size_t needed) {
         assert(get_posn() + needed <= len);
     }
 };

--- a/include/mfmidi.h
+++ b/include/mfmidi.h
@@ -60,7 +60,7 @@ protected:
     virtual void Mf_chanpressure(int,int) = 0;
     virtual void Mf_sysex(size_t, unsigned char*) = 0;
     virtual void Mf_arbitrary(size_t, unsigned char*) = 0;
-    virtual void Mf_metamisc(int,int,unsigned char*) = 0;
+    virtual void Mf_metamisc(int, size_t, unsigned char*) = 0;
     virtual void Mf_seqnum(int) = 0;
     virtual void Mf_smpte(int,int,int,int,int) = 0;
     virtual void Mf_timesig(int,int,int,int) = 0;
@@ -70,7 +70,7 @@ protected:
     virtual void Mf_text(int, size_t, unsigned char*) = 0;
 
 private:
-    ptrdiff_t Mf_toberead;
+    long Mf_toberead;
 
     long readvarinum();
     int32_t read32bit();

--- a/include/mfmidi.h
+++ b/include/mfmidi.h
@@ -1,3 +1,6 @@
+#include <cstddef>
+#include <cstdint>
+
 #define NOTEOFF 0x80
 #define NOTEON 0x90
 #define PRESSURE 0xa0
@@ -55,23 +58,23 @@ protected:
     virtual void Mf_pitchbend(int,int,int) = 0;
     virtual void Mf_program(int,int) = 0;
     virtual void Mf_chanpressure(int,int) = 0;
-    virtual void Mf_sysex(int,unsigned char*) = 0;
-    virtual void Mf_arbitrary(int,unsigned char*) = 0;
+    virtual void Mf_sysex(size_t, unsigned char*) = 0;
+    virtual void Mf_arbitrary(size_t, unsigned char*) = 0;
     virtual void Mf_metamisc(int,int,unsigned char*) = 0;
     virtual void Mf_seqnum(int) = 0;
     virtual void Mf_smpte(int,int,int,int,int) = 0;
     virtual void Mf_timesig(int,int,int,int) = 0;
     virtual void Mf_tempo(int) = 0;
     virtual void Mf_keysig(int,int) = 0;
-    virtual void Mf_sqspecific(int,unsigned char*) = 0;
-    virtual void Mf_text(int,int,unsigned char*) = 0;
+    virtual void Mf_sqspecific(size_t, unsigned char*) = 0;
+    virtual void Mf_text(int, size_t, unsigned char*) = 0;
 
 private:
-    long Mf_toberead;
+    ptrdiff_t Mf_toberead;
 
     long readvarinum();
-    long read32bit();
-    int read16bit();
+    int32_t read32bit();
+    int16_t read16bit();
     void msgenlarge();
     unsigned char *msg();
     int readheader();
@@ -79,11 +82,11 @@ private:
     void sysex();
     void msginit();
     int egetc();
-    int msgleng();
+    size_t msgleng();
 
     int readmt(const char*,int);
-    long to32bit(int,int,int,int);
-    int to16bit(int,int);
+    int32_t to32bit(int8_t, int8_t, int8_t, int8_t);
+    int16_t to16bit(int8_t, int8_t);
     void mferror(const char *);
     void badbyte(int);
     void metaevent(int);
@@ -91,8 +94,8 @@ private:
     void chanmessage(int,int,int);
 
     unsigned char *Msgbuff;
-    long Msgsize;
-    long Msgindex;
+    size_t Msgsize;
+    size_t Msgindex;
 };
 
 

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -16,12 +16,6 @@
 #include "algrd_internal.h"
 #include "algsmfrd_internal.h"
 
-#if defined(_WIN32)
-// 4311 is type cast ponter to long warning
-// 4996 is warning against strcpy
-// 4267 is size_t to long warning
-#pragma warning(disable: 4311 4996 4267)
-#endif
 DLLEXPORT Alg_atoms symbol_table;
 Serial_read_buffer Alg_track::ser_read_buf; // declare the static variables
 Serial_write_buffer Alg_track::ser_write_buf;
@@ -1468,7 +1462,7 @@ void Alg_track::serialize_track()
     ser_write_buf.set_char('L');
     ser_write_buf.set_char('G');
     ser_write_buf.set_char('T');
-    long length_offset = ser_write_buf.get_posn(); // save location for track length
+    size_t length_offset = ser_write_buf.get_posn(); // save location for track length
     ser_write_buf.set_int32(0); // room to write track length
     ser_write_buf.set_int32(units_are_seconds);
     ser_write_buf.set_double(beat_dur);
@@ -1488,7 +1482,7 @@ void Alg_track::serialize_track()
             ser_write_buf.set_float(note->pitch);
             ser_write_buf.set_float(note->loud);
             ser_write_buf.set_double(note->dur);
-            long parm_num_offset = ser_write_buf.get_posn();
+            size_t parm_num_offset = ser_write_buf.get_posn();
             long parm_num = 0;
             ser_write_buf.set_int32(0); // placeholder for no. parameters
             Alg_parameters *parms = note->parameters;
@@ -1573,10 +1567,6 @@ Alg_track *Alg_track::unserialize(void *buffer, size_t len)
     }
 }
 
-
-#if defined(_WIN32)
-#pragma warning(disable: 4800) // long to bool performance warning
-#endif
 
 /* Note: this Alg_seq must have a default initialized Alg_time_map.
  * It will be filled in with data from the ser_read_buf buffer.
@@ -1714,9 +1704,6 @@ void Alg_track::unserialize_parameter(Alg_parameter *parm_ptr)
     } /* switch (parm_ptr->attr_type()) */
 }
 
-#if defined(_WIN32)
-#pragma warning(default: 4800)
-#endif
 
 void Alg_track::set_time_map(Alg_time_map *map)
 {
@@ -2907,9 +2894,6 @@ Alg_track *Alg_seq::track(size_t i)
     return &(track_list[i]);
 }
 
-#if defined(_WIN32)
-#pragma warning(disable: 4715) // ok not to return a value here
-#endif
 
 Alg_event *&Alg_seq::operator[](size_t i)
 {
@@ -2925,9 +2909,6 @@ Alg_event *&Alg_seq::operator[](size_t i)
     // throw runtime error instead of using assert
     throw std::runtime_error("&Alg_seq::operator[] - out of bounds");
 }
-#if defined(_WIN32)
-#pragma warning(default: 4715)
-#endif
 
 
 void Alg_seq::convert_to_beats()

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -74,8 +74,8 @@ Alg_attribute Alg_atoms::insert_new(const char *name, char attr_type)
 
 Alg_attribute Alg_atoms::insert_attribute(Alg_attribute attr)
 {
-    // should use hash algorithm
-    for (int i = 0; i < len; i++) {
+    // TODO: Should use hash algorithm
+    for (size_t i = 0; i < len; i++) {
         if (!strcmp(attr, atoms[i])) {
             return atoms[i];
         }
@@ -87,7 +87,7 @@ Alg_attribute Alg_atoms::insert_attribute(Alg_attribute attr)
 Alg_attribute Alg_atoms::insert_string(const char *name)
 {
     char attr_type = name[strlen(name) - 1];
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         if (attr_type == atoms[i][0] &&
             !strcmp(name, atoms[i] + 1)) {
             return atoms[i];
@@ -679,7 +679,7 @@ void Alg_events::insert(Alg_event *event)
     events[len] = event;
     len++;
     // find insertion point: (this could be a binary search)
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         if (events[i]->time > event->time) {
             // insert event at i
             memmove(&events[i + 1], &events[i],
@@ -690,9 +690,9 @@ void Alg_events::insert(Alg_event *event)
     }
 }
 
-Alg_event *Alg_events::uninsert(long index)
+Alg_event *Alg_events::uninsert(size_t index)
 {
-    assert(0 <= index && index < len);
+    assert(index < len);
     Alg_event *event = events[index];
     //printf("memmove: %x from %x (%d)\n", events + index, events + index + 1,
     //        sizeof(Alg_event*) * (len - index - 1));
@@ -734,9 +734,9 @@ Alg_event_list::Alg_event_list(Alg_track *owner)
 }
 
 
-Alg_event *&Alg_event_list::operator [](int i)
+Alg_event *&Alg_event_list::operator[](size_t i)
 {
-    assert(i >= 0 && i < len);
+    assert(i < len);
     return events[i];
 }
 
@@ -745,7 +745,7 @@ void Alg_event_list::set_start_time(Alg_event *event, double t)
     // For Alg_event_list, find the owner and do the update there
     // For Alg_track, change the time and move the event to the right place
     // For Alg_seq, find the track and do the update there
-    long index = 0;
+    size_t index = 0;
     Alg_track *track_ptr = nullptr;
 
     if (type == 'e') { // this is an Alg_event_list
@@ -767,7 +767,7 @@ void Alg_event_list::set_start_time(Alg_event *event, double t)
         }
     } else { // type == 's', an Alg_seq
         Alg_seq *seq = (Alg_seq*) this;
-        for (int i = 0; i < seq->tracks(); i++) {
+        for (size_t i = 0; i < seq->tracks(); i++) {
             track_ptr = seq->track(i);
             // if you implemented binary search, you could call it
             // instead of this loop too.
@@ -801,9 +801,9 @@ void Alg_beats::expand()
 }
 
 
-void Alg_beats::insert(long i, Alg_beat *beat)
+void Alg_beats::insert(size_t i, Alg_beat *beat)
 {
-    assert(i >= 0 && i <= len);
+    assert(i <= len);
     if (maxlen <= len) {
         expand();
     }
@@ -821,7 +821,7 @@ Alg_time_map::Alg_time_map(Alg_time_map *map)
     // new_beats[0] = map->beats[0];
        // this is commented because
        // both new_beats[0] and map->beats[0] should be (0, 0)
-    for (int i = 1; i < map->beats.len; i++) {
+    for (size_t i = 1; i < map->beats.len; i++) {
         beats.insert(i, &map->beats[i]);
     }
     last_tempo = map->last_tempo;
@@ -832,7 +832,7 @@ Alg_time_map::Alg_time_map(Alg_time_map *map)
 void Alg_time_map::show()
 {
     printf("Alg_time_map: ");
-    for (int i = 0; i < beats.len; i++) {
+    for (size_t i = 0; i < beats.len; i++) {
         Alg_beat &b = beats[i];
         printf("(%g, %g) ", b.time, b.beat);
     }
@@ -840,9 +840,9 @@ void Alg_time_map::show()
 }
 
 
-long Alg_time_map::locate_time(double time)
+size_t Alg_time_map::locate_time(double time)
 {
-    int i = 0;
+    size_t i = 0;
     while ((i < beats.len) && (time > beats[i].time)) {
         i++;
     }
@@ -850,9 +850,9 @@ long Alg_time_map::locate_time(double time)
 }
 
 
-long Alg_time_map::locate_beat(double beat)
+size_t Alg_time_map::locate_beat(double beat)
 {
-    int i = 0;
+    size_t i = 0;
     while ((i < beats.len) && (beat > beats[i].beat)) {
         i++;
     }
@@ -867,9 +867,9 @@ double Alg_time_map::beat_to_time(double beat)
     if (beat <= 0) {
         return beat;
     }
-    int i = locate_beat(beat);
+    size_t i = locate_beat(beat);
     // case 1: beat is between two time/beat pairs
-    if (0 < i && i < beats.len) {
+    if (i < beats.len) {
         mbi = &beats[i - 1];
         mbi1 = &beats[i];
     // case 2: beat is beyond last time/beat pair
@@ -902,7 +902,7 @@ double Alg_time_map::time_to_beat(double time)
     if (time <= 0.0) {
         return time;
     }
-    int i = locate_time(time);
+    size_t i = locate_time(time);
     if (i == beats.len) {
         if (last_tempo_flag) {
             return beats[i - 1].beat +
@@ -925,7 +925,7 @@ double Alg_time_map::time_to_beat(double time)
 
 void Alg_time_map::insert_beat(double time, double beat)
 {
-    int i = locate_time(time); // i is insertion point
+    size_t i = locate_time(time); // i is insertion point
     if (i < beats.len && within(beats[i].time, time, 0.000001)) {
         // replace beat if time is already in the map
         beats[i].beat = beat;
@@ -938,14 +938,12 @@ void Alg_time_map::insert_beat(double time, double beat)
     // beats[i] contains new beat
     // make sure we didn't generate a zero tempo.
     // if so, space beats by one microbeat as necessary
-    long j = i;
-    if (j == 0) {
-        j = 1; // do not adjust beats[0]
-    }
-    while (j < beats.len &&
-        beats[j - 1].beat + 0.000001 >= beats[j].beat) {
+    for (
+        size_t j = std::max(1UL, i); // do not adjust beats[0]
+        j < beats.len && beats[j - 1].beat + 0.000001 >= beats[j].beat;
+        j++
+    ) {
         beats[j].beat = beats[j - 1].beat + 0.000001;
-        j++;
     }
 }
 
@@ -958,7 +956,7 @@ bool Alg_time_map::insert_tempo(double tempo, double beat)
         return false;
     }
     double time = beat_to_time(beat);
-    long i = locate_time(time);
+    size_t i = locate_time(time);
     if (i >= beats.len || !within(beats[i].time, time, 0.000001)) {
         insert_beat(time, beat);
     }
@@ -995,7 +993,7 @@ double Alg_time_map::get_tempo(double beat)
     if (beat < 0) {
         return ALG_DEFAULT_BPM / 60.0;
     }
-    long i = locate_beat(beat);
+    size_t i = locate_beat(beat);
     // this code is similar to beat_to_time() so far, but we want to get
     // beyond beat if possible because we want the tempo FOLLOWING beat
     // (Consider the case beat == 0.0)
@@ -1034,8 +1032,8 @@ bool Alg_time_map::set_tempo(double tempo, double start_beat, double end_beat)
     // change the tempo
     insert_beat(beat_to_time(start_beat), start_beat);
     insert_beat(beat_to_time(end_beat), end_beat);
-    long start_x = locate_beat(start_beat) + 1;
-    long stop_x = locate_beat(end_beat);
+    size_t start_x = locate_beat(start_beat) + 1;
+    size_t stop_x = locate_beat(end_beat);
     while (stop_x < beats.len) {
         beats[start_x] = beats[stop_x];
         start_x++;
@@ -1059,11 +1057,11 @@ bool Alg_time_map::stretch_region(double b0, double b1, double dur)
     // insert a beat if necessary at b0 and b1
     insert_beat(t0, b0);
     insert_beat(t1, b1);
-    long start_x = locate_beat(b0);
-    long stop_x = locate_beat(b1);
+    size_t start_x = locate_beat(b0);
+    size_t stop_x = locate_beat(b1);
     double orig_time = beats[start_x].time;
     double prev_time = orig_time;
-    for (int i = start_x + 1; i < beats.len; i++) {
+    for (size_t i = start_x + 1; i < beats.len; i++) {
         double delta = beats[i].time - orig_time;
         if (i <= stop_x) { // change tempo to next Alg_beat
             delta *= scale;
@@ -1080,9 +1078,9 @@ void Alg_time_map::trim(double start, double end, bool units_are_seconds)
 {
     // extract the time map from start to end and shift to time zero
     // start and end are time in seconds if units_are_seconds is true
-    int i = 0; // index into beats
-    int start_index; // index of first breakpoint after start
-    int count = 1;
+    size_t i = 0; // index into beats
+    size_t start_index; // index of first breakpoint after start
+    size_t count = 1;
     double initial_beat = start;
     double final_beat = end;
     if (units_are_seconds) {
@@ -1141,7 +1139,7 @@ void Alg_time_map::cut(double start, double len, bool units_are_seconds)
     double end = start + len;
     double initial_beat = start;
     double final_beat = end;
-    int i = 0;
+    size_t i = 0;
 
     if (units_are_seconds) {
         initial_beat = time_to_beat(start);
@@ -1208,7 +1206,7 @@ void Alg_time_map::paste(double beat, Alg_track *tr)
     double dur = tr->get_beat_dur();
     double tr_end_time = from_map->beat_to_time(dur);
     // add offset to make room for insert
-    int i = locate_beat(beat);
+    size_t i = locate_beat(beat);
     while (i < length()) {
         beats[i].beat += dur;
         beats[i].time += tr_end_time;
@@ -1223,7 +1221,7 @@ void Alg_time_map::paste(double beat, Alg_track *tr)
     // insert_beat(time + tr_end_time, beat + dur);
     // printf("after ending point insert\n");
     // show();
-    int j = from_map->locate_beat(dur);
+    size_t j = from_map->locate_beat(dur);
     for (i = 0; i < j; i++) {
         insert_beat(from[i].time + time,  // shift by time
                     from[i].beat + beat); // and beat
@@ -1239,7 +1237,7 @@ void Alg_time_map::insert_time(double start, double len)
     // compute beat offset = (delta beat / delta time) * len
     // add len,beat offset to each following Alg_beat
     // show();
-    int i = locate_time(start); // start <= beats[i].time
+    size_t i = locate_time(start); // start <= beats[i].time
     if (beats[i].time == start) {
         i++; // start < beats[i].time
     }
@@ -1260,7 +1258,7 @@ void Alg_time_map::insert_time(double start, double len)
 
 void Alg_time_map::insert_beats(double start, double len)
 {
-    int i = locate_beat(start); // start <= beats[i].beat
+    size_t i = locate_beat(start); // start <= beats[i].beat
     if (beats[i].beat == start) {
         i++;
     }
@@ -1304,7 +1302,7 @@ Alg_track::Alg_track(Alg_track &track)
 {
     type = 't';
     time_map = nullptr;
-    for (int i = 0; i < track.length(); i++) {
+    for (size_t i = 0; i < track.length(); i++) {
       append(copy_event(track.events[i]));
     }
     set_time_map(track.time_map);
@@ -1317,7 +1315,7 @@ Alg_track::Alg_track(Alg_event_list &event_list, Alg_time_map *map,
 {
     type = 't';
     time_map = nullptr;
-    for (int i = 0; i < event_list.length(); i++) {
+    for (size_t i = 0; i < event_list.length(); i++) {
         append(copy_event(event_list[i]));
     }
     set_time_map(map);
@@ -1325,7 +1323,7 @@ Alg_track::Alg_track(Alg_event_list &event_list, Alg_time_map *map,
 }
 
 
-void Alg_track::serialize(void **buffer, long *bytes)
+void Alg_track::serialize(void **buffer, size_t *bytes)
 {
     // first determine whether this is a seq or a track.
     // if it is a seq, then we will write the time map and a set of tracks
@@ -1395,7 +1393,7 @@ void Alg_track::serialize(void **buffer, long *bytes)
 }
 
 
-void Alg_seq::serialize(void **buffer, long *bytes)
+void Alg_seq::serialize(void **buffer, size_t *bytes)
 {
     assert(get_type() == 's');
     ser_write_buf.init_for_write();
@@ -1404,16 +1402,12 @@ void Alg_seq::serialize(void **buffer, long *bytes)
 }
 
 
-void Serial_write_buffer::check_buffer(long needed)
+void Serial_write_buffer::check_buffer(size_t needed)
 {
     if (len < (ptr - buffer) + needed) { // do we need more space?
-        long new_len = len * 2; // exponential growth is important
-        // initially, length is zero, so bump new_len to a starting value
-        if (new_len == 0) {
-            new_len = 1024;
-        }
-         // make sure new_len is as big as needed
-        new_len = std::max(needed, new_len);
+        // initially, length is zero, so bump new_len to a minimum starting value
+        // make sure new_len is as big as needed; exponential growth is important
+        size_t new_len = std::max({needed, len * 2, 1024UL});
         char *new_buffer = new char[new_len]; // allocate space
         ptr = new_buffer + (ptr - buffer); // relocate ptr to new buffer
         if (len > 0) { // we had a buffer already
@@ -1428,16 +1422,15 @@ void Serial_write_buffer::check_buffer(long needed)
 
 void Alg_seq::serialize_seq()
 {
-    int i; // loop counters
     // we can easily compute how much buffer space we need until we
     // get to tracks, so expand at least that much
-    long needed = 64 + 16 * time_map->beats.len + 24 * time_sig.length();
+    size_t needed = 64 + 16 * time_map->beats.len + 24 * time_sig.length();
     ser_write_buf.check_buffer(needed);
     ser_write_buf.set_char('A');
     ser_write_buf.set_char('L');
     ser_write_buf.set_char('G');
     ser_write_buf.set_char('S');
-    long length_offset = ser_write_buf.get_posn();
+    size_t length_offset = ser_write_buf.get_posn();
     ser_write_buf.set_int32(0); // leave room to come back and write length
     ser_write_buf.set_int32(channel_offset_per_track);
     ser_write_buf.set_int32(units_are_seconds);
@@ -1446,20 +1439,20 @@ void Alg_seq::serialize_seq()
     ser_write_buf.set_double(time_map->last_tempo);
     ser_write_buf.set_int32(time_map->last_tempo_flag);
     ser_write_buf.set_int32(time_map->beats.len);
-    for (i = 0; i < time_map->beats.len; i++) {
+    for (size_t i = 0; i < time_map->beats.len; i++) {
         ser_write_buf.set_double(time_map->beats[i].time);
         ser_write_buf.set_double(time_map->beats[i].beat);
     }
     ser_write_buf.set_int32(time_sig.length());
     ser_write_buf.pad();
-    for (i = 0; i < time_sig.length(); i++) {
+    for (size_t i = 0; i < time_sig.length(); i++) {
         ser_write_buf.set_double(time_sig[i].beat);
         ser_write_buf.set_double(time_sig[i].num);
         ser_write_buf.set_double(time_sig[i].den);
     }
     ser_write_buf.set_int32(tracks());
     ser_write_buf.pad();
-    for (i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         track(i)->serialize_track();
     }
     // do not include ALGS, include padding at end
@@ -1470,7 +1463,6 @@ void Alg_seq::serialize_seq()
 void Alg_track::serialize_track()
 {
     // to simplify the code, copy from parameter addresses to locals
-    int j;
     ser_write_buf.check_buffer(32);
     ser_write_buf.set_char('A');
     ser_write_buf.set_char('L');
@@ -1482,7 +1474,7 @@ void Alg_track::serialize_track()
     ser_write_buf.set_double(beat_dur);
     ser_write_buf.set_double(real_dur);
     ser_write_buf.set_int32(len);
-    for (j = 0; j < len; j++) {
+    for (size_t j = 0; j < len; j++) {
         ser_write_buf.check_buffer(24);
         Alg_event *event = (*this)[j];
         ser_write_buf.set_int32(event->get_selected());
@@ -1558,7 +1550,7 @@ void Alg_track::serialize_parameter(Alg_parameter *parm)
 
 
 
-Alg_track *Alg_track::unserialize(void *buffer, long len)
+Alg_track *Alg_track::unserialize(void *buffer, size_t len)
 {
     assert(len > 8);
     ser_read_buf.init_for_read(buffer, len);
@@ -1597,7 +1589,7 @@ void Alg_seq::unserialize_seq()
                               && ser_read_buf.get_char() == 'G'
                               && ser_read_buf.get_char() == 'S';
     assert(algs);
-    [[maybe_unused]] long len = ser_read_buf.get_int32();
+    [[maybe_unused]] size_t len = ser_read_buf.get_int32();
     assert(ser_read_buf.get_len() >= len);
     channel_offset_per_track = ser_read_buf.get_int32();
     units_are_seconds = ser_read_buf.get_int32() != 0;
@@ -1645,8 +1637,8 @@ void Alg_track::unserialize_track()
                               && ser_read_buf.get_char() == 'G'
                               && ser_read_buf.get_char() == 'T';
     assert(algt);
-    [[maybe_unused]] long offset = ser_read_buf.get_posn(); // stored length does not include 'ALGT'
-    [[maybe_unused]] long bytes = ser_read_buf.get_int32();
+    [[maybe_unused]] size_t offset = ser_read_buf.get_posn(); // stored length does not include 'ALGT'
+    [[maybe_unused]] size_t bytes = ser_read_buf.get_int32();
     assert(bytes <= ser_read_buf.get_len() - offset);
     units_are_seconds = static_cast<bool>(ser_read_buf.get_int32());
     beat_dur = ser_read_buf.get_double();
@@ -1746,9 +1738,7 @@ void Alg_track::convert_to_beats()
 {
     if (units_are_seconds) {
         units_are_seconds = false;
-        long i;
-
-        for (i = 0; i < length(); i++) {
+        for (size_t i = 0; i < length(); i++) {
             Alg_event *e = events[i];
             double beat = time_map->time_to_beat(e->time);
             if (e->is_note()) {
@@ -1767,8 +1757,7 @@ void Alg_track::convert_to_seconds()
     if (!units_are_seconds) {
         last_note_off = time_map->beat_to_time(last_note_off);
         units_are_seconds = true;
-        long i;
-        for (i = 0; i < length(); i++) {
+        for (size_t i = 0; i < length(); i++) {
             Alg_event *e = events[i];
             double time = time_map->beat_to_time(e->time);
             if (e->is_note()) {
@@ -1832,10 +1821,9 @@ Alg_track *Alg_track::cut(double t, double len, bool all)
         track->set_real_dur(time_map->beat_to_time(t + len) -
                             time_map->beat_to_time(t));
     }
-    int i;
-    int new_len = 0;
+    size_t new_len = 0;
     int change = 0;
-    for (i = 0; i < length(); i++) {
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->overlap(t, len, all)) {
             event->time -= t;
@@ -1873,8 +1861,7 @@ Alg_track *Alg_track::copy(double t, double len, bool all)
         track->set_real_dur(time_map->beat_to_time(t + len) -
                             time_map->beat_to_time(t));
     }
-    int i;
-    for (i = 0; i < length(); i++) {
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->overlap(t, len, all)) {
             Alg_event *new_event = copy_event(event);
@@ -1912,13 +1899,12 @@ void Alg_track::paste(double t, Alg_event_list *seq)
     // are not guaranteed that the events are in time
     // order, but currently, only a true seq is allowed)
 
-    int i;
-    for (i = 0; i < length(); i++) {
+    for (size_t i = 0; i < length(); i++) {
         if (events[i]->time > t - ALG_EPS) {
             events[i]->time += dur;
         }
     }
-    for (i = 0; i < seq->length(); i++) {
+    for (size_t i = 0; i < seq->length(); i++) {
         Alg_event *new_event = copy_event((*seq)[i]);
         new_event->time += t;
         insert(new_event);
@@ -1939,7 +1925,7 @@ void Alg_track::paste(double t, Alg_event_list *seq)
 void Alg_track::merge(double t, Alg_event_list *seq)
 {
     Alg_event_list &s = *seq;
-    for (int i = 0; i < s.length(); i++) {
+    for (size_t i = 0; i < s.length(); i++) {
         Alg_event *new_event;
         if (s[i]->is_note()) {
             new_event = new Alg_note((Alg_note*) s[i]);
@@ -1954,9 +1940,8 @@ void Alg_track::merge(double t, Alg_event_list *seq)
 
 void Alg_track::clear(double t, double len, bool all)
 {
-    int i;
-    int move_to = 0;
-    for (i = 0; i < length(); i++) {
+    size_t move_to = 0;
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->overlap(t, len, all)) {
             delete events[i];
@@ -1978,9 +1963,8 @@ void Alg_track::clear(double t, double len, bool all)
 
 void Alg_track::silence(double t, double len, bool all)
 {
-    int i;
-    int move_to = 0;
-    for (i = 0; i < length(); i++) {
+    size_t move_to = 0;
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->overlap(t, len, all)) {
             delete events[i];
@@ -1999,8 +1983,7 @@ void Alg_track::silence(double t, double len, bool all)
 
 void Alg_track::insert_silence(double t, double len)
 {
-    int i;
-    for (i = 0; i < length(); i++) {
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->time > t - ALG_EPS) {
             event->time += len;
@@ -2012,7 +1995,6 @@ void Alg_track::insert_silence(double t, double len)
 Alg_event_list *Alg_track::find(double t, double len, bool all,
                          long channel_mask, long event_type_mask)
 {
-    int i;
     Alg_event_list *list = new Alg_event_list(this);
     if (units_are_seconds) { // t and len are seconds
         list->set_real_dur(len);
@@ -2023,7 +2005,7 @@ Alg_event_list *Alg_track::find(double t, double len, bool all,
                            get_time_map()->beat_to_time(t));
         list->set_beat_dur(len);
     }
-    for (i = 0; i < length(); i++) {
+    for (size_t i = 0; i < length(); i++) {
         Alg_event *event = events[i];
         if (event->overlap(t, len, all)) {
             if ((channel_mask == 0 ||
@@ -2055,7 +2037,7 @@ void Alg_time_sigs::expand()
 void Alg_time_sigs::insert(double beat, double num, double den, bool force)
 {
     // find insertion point:
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         if (within(time_sigs[i].beat, beat, ALG_EPS)) {
             // overwrite location i with new info
             time_sigs[i].beat = beat;
@@ -2104,17 +2086,17 @@ void Alg_time_sigs::insert(double beat, double num, double den, bool force)
 void Alg_time_sigs::show()
 {
     printf("Alg_time_sig: ");
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         printf("(%g: %g/%g) ", time_sigs[i].beat, time_sigs[i].num, time_sigs[i].den);
     }
     printf("\n");
 }
 
 
-int Alg_time_sigs::find_beat(double beat)
+size_t Alg_time_sigs::find_beat(double beat)
 {
     // index where you would insert a new time signature at beat
-    int i = 0;
+    size_t i = 0;
     while (i < len && time_sigs[i].beat < beat - ALG_EPS) {
         i++;
     }
@@ -2144,7 +2126,7 @@ void Alg_time_sigs::cut(double start, double end, double dur)
     // and does not fall on a bar line, insert a time signature at
     // the time of the bar line to retain relative bar line positions
 
-    int i = find_beat(end);
+    size_t i = find_beat(end);
     // i is where you would insert a new time sig at beat,
     // Case 1: beat coincides with a time sig at i. Time signature
     // at beat means that there is a barline at beat, so when beat
@@ -2224,7 +2206,7 @@ void Alg_time_sigs::cut(double start, double end, double dur)
     // Find the time signature at end:
     double end_num = 4.0; // default if no time signature specified
     double end_den = 4.0;
-    int j = find_beat(end);
+    size_t j = find_beat(end);
     if (j != 0) {
         end_num = time_sigs[j - 1].num;
         end_den = time_sigs[j - 1].den;
@@ -2241,8 +2223,8 @@ void Alg_time_sigs::cut(double start, double end, double dur)
     // end, if there is one there. Be careful with ALG_EPS on that one.)
 
     // since we may have inserted a time signature, find position again:
-    int i0 = find_beat(start);
-    int i1 = i0;
+    size_t i0 = find_beat(start);
+    size_t i1 = i0;
     // scan to end of cut region
     while (i1 < len && time_sigs[i1].beat < end - ALG_EPS) {
         i1++;
@@ -2391,7 +2373,7 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     if (len == 0 && from.len == 0) {
         return; // default applies
     }
-    int i = find_beat(start);
+    size_t i = find_beat(start);
     // remember the time signature at the splice point
     double num_after_splice = 4;
     double den_after_splice = 4; // default
@@ -2524,7 +2506,7 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
 
 void Alg_time_sigs::insert_beats(double start, double dur)
 {
-    int i = find_beat(start);
+    size_t i = find_beat(start);
 
     // time_sigs[i] is after beat and needs to shift
     // Compute the time of the first bar at or after beat so that
@@ -2559,7 +2541,7 @@ void Alg_time_sigs::insert_beats(double start, double dur)
     // invariant: i is index of next time signature after start
 
     // increase beat times from i to len - 1 by dur
-    for (int j = i; j < len; j++) {
+    for (size_t j = i; j < len; j++) {
         time_sigs[j].beat += dur;
     }
 
@@ -2590,7 +2572,7 @@ void Alg_time_sigs::insert_beats(double start, double dur)
 
 double Alg_time_sigs::nearest_beat(double beat)
 {
-    int i = find_beat(beat);
+    size_t i = find_beat(beat);
     // i is where we would insert time signature at beat
     // case 1: there is no time signature
     if (i == 0 && len == 0) {
@@ -2653,14 +2635,13 @@ void Alg_tracks::append(Alg_track *track)
 }
 
 
-void Alg_tracks::add_track(int track_num, Alg_time_map *time_map,
+void Alg_tracks::add_track(size_t track_num, Alg_time_map *time_map,
                            bool seconds)
     // Create a new track at index track_num.
     // If track already exists, this call does nothing.
     // If highest previous track is not at track_num-1, then
     // create tracks at len, len+1, ..., track_num.
 {
-    assert(track_num >= 0);
     if (track_num == maxlen) {
         // use eponential growth to insert tracks sequentially
         expand();
@@ -2684,8 +2665,8 @@ void Alg_tracks::reset()
 {
     // all track events are incorporated into the seq,
     // so all we need to delete are the arrays of pointers
-    for (int i = 0; i < len; i++) {
-        // printf("deleting track at %d (%x, this %x) = %x\n", i, &(tracks[i]),
+    for (size_t i = 0; i < len; i++) {
+        // printf("deleting track at %zu (%x, this %x) = %x\n", i, &(tracks[i]),
         //       this, tracks[i]);
         delete tracks[i];
     }
@@ -2698,7 +2679,7 @@ void Alg_tracks::reset()
 
 void Alg_tracks::set_in_use(bool flag)
 {
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         tracks[i]->in_use = flag;
     }
 }
@@ -2732,9 +2713,9 @@ void Alg_iterator::expand()
 
 void Alg_iterator::show()
 {
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         Alg_pending_event *p = &(pending_events[i]);
-        printf("    %d: %p[%ld]@%g on %d\n", i, static_cast<void*>(p->events), p->index,
+        printf("    %zu: %p[%ld]@%g on %d\n", i, static_cast<void*>(p->events), p->index,
                p->offset, p->note_on);
     }
 }
@@ -2759,7 +2740,7 @@ bool Alg_iterator::earlier(int i, int j)
 }
 
 
-void Alg_iterator::insert(Alg_events *events, long index,
+void Alg_iterator::insert(Alg_events *events, size_t index,
                           bool note_on, void *cookie, double offset)
 {
     if (len == maxlen) {
@@ -2797,7 +2778,7 @@ void Alg_iterator::insert(Alg_events *events, long index,
 }
 
 
-bool Alg_iterator::remove_next(Alg_events *&events, long &index,
+bool Alg_iterator::remove_next(Alg_events *&events, size_t &index,
                                bool &note_on, void *&cookie,
                                double &offset, double &time)
 {
@@ -2814,8 +2795,8 @@ bool Alg_iterator::remove_next(Alg_events *&events, long &index,
     len--;
     pending_events[0] = pending_events[len];
     // sift down
-    long loc = 0;
-    long loc_child = FIRST_CHILD(loc);
+    size_t loc = 0;
+    size_t loc_child = FIRST_CHILD(loc);
     while (loc_child < len) {
         if (loc_child + 1 < len) {
             if (earlier(loc_child + 1, loc_child)) {
@@ -2885,7 +2866,7 @@ void Alg_seq::seq_from_track(Alg_track &tr)
         channel_offset_per_track = s.channel_offset_per_track;
         add_track(s.tracks() - 1);
         // copy each track
-        for (int i = 0; i < tracks(); i++) {
+        for (size_t i = 0; i < tracks(); i++) {
             Alg_track &from_track = *(s.track(i));
             Alg_track &to_track = *(track(i));
             to_track.set_beat_dur(from_track.get_beat_dur());
@@ -2893,7 +2874,7 @@ void Alg_seq::seq_from_track(Alg_track &tr)
             if (from_track.get_units_are_seconds()) {
                 to_track.convert_to_seconds();
             }
-            for (int j = 0; j < from_track.length(); j++) {
+            for (size_t j = 0; j < from_track.length(); j++) {
                 Alg_event *event = copy_event(from_track[j]);
                 to_track.append(event);
             }
@@ -2904,7 +2885,7 @@ void Alg_seq::seq_from_track(Alg_track &tr)
         Alg_track *to_track = track(0);
         to_track->set_beat_dur(tr.get_beat_dur());
         to_track->set_real_dur(tr.get_real_dur());
-        for (int j = 0; j < tr.length(); j++) {
+        for (size_t j = 0; j < tr.length(); j++) {
             Alg_event *event = copy_event(tr[j]);
             to_track->append(event);
         }
@@ -2914,15 +2895,15 @@ void Alg_seq::seq_from_track(Alg_track &tr)
 }
 
 
-int Alg_seq::tracks()
+size_t Alg_seq::tracks()
 {
     return track_list.length();
 }
 
 
-Alg_track *Alg_seq::track(int i)
+Alg_track *Alg_seq::track(size_t i)
 {
-    assert(0 <= i && i < track_list.length());
+    assert(i < track_list.length());
     return &(track_list[i]);
 }
 
@@ -2930,18 +2911,16 @@ Alg_track *Alg_seq::track(int i)
 #pragma warning(disable: 4715) // ok not to return a value here
 #endif
 
-Alg_event *&Alg_seq::operator[](int i)
+Alg_event *&Alg_seq::operator[](size_t i)
 {
-    int ntracks = track_list.length();
-    int tr = 0;
-    while (tr < ntracks) {
+    size_t ntracks = track_list.length();
+    for (size_t tr = 0; tr < ntracks; tr++) {
         Alg_track *a_track = track(tr);
         if (a_track && i < a_track->length()) {
             return (*a_track)[i];
         } else if (a_track) {
             i -= a_track->length();
         }
-        tr++;
     }
     // throw runtime error instead of using assert
     throw std::runtime_error("&Alg_seq::operator[] - out of bounds");
@@ -2956,7 +2935,7 @@ void Alg_seq::convert_to_beats()
     if (!units_are_seconds) {
         return;
     }
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         track(i)->convert_to_beats();
     }
     // note that the Alg_seq inherits units_are_seconds from an
@@ -2974,7 +2953,7 @@ void Alg_seq::convert_to_seconds()
     //printf("convert_to_seconds, tracks %d\n", tracks());
     //printf("last_tempo of seq: %g on map %x\n",
     //       get_time_map()->last_tempo, get_time_map());
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         //printf("last_tempo of track %d: %g on %x\n", i,
         //       track(i)->get_time_map()->last_tempo,
         //       track(i)->get_time_map());
@@ -2989,10 +2968,10 @@ void Alg_seq::convert_to_seconds()
 }
 
 
-Alg_track *Alg_seq::cut_from_track(int track_num, double start,
+Alg_track *Alg_seq::cut_from_track(size_t track_num, double start,
                                       double dur, bool all)
 {
-    assert(track_num >= 0 && track_num < tracks());
+    assert(track_num < tracks());
     Alg_track *tr = track(track_num);
     return tr->cut(start, dur, all);
 }
@@ -3001,7 +2980,7 @@ Alg_track *Alg_seq::cut_from_track(int track_num, double start,
 void Alg_seq::copy_time_sigs_to(Alg_seq *dest)
 {
     // copy time signatures
-    for (int i = 0; i < time_sig.length(); i++) {
+    for (size_t i = 0; i < time_sig.length(); i++) {
         dest->time_sig.insert(time_sig[i].beat, time_sig[i].num,
                               time_sig[i].den);
     }
@@ -3011,7 +2990,7 @@ void Alg_seq::copy_time_sigs_to(Alg_seq *dest)
 void Alg_seq::set_time_map(Alg_time_map *map)
 {
     Alg_track::set_time_map(map);
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         track(i)->set_time_map(map);
     }
 }
@@ -3039,7 +3018,7 @@ Alg_seq *Alg_seq::cut(double start, double len, bool all)
     result->units_are_seconds = units_are_seconds;
     result->track_list.reset();
 
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         Alg_track *cut_track = cut_from_track(i, start, len, all);
         result->track_list.append(cut_track);
         // initially, result->last_note_off is zero. We want to know the
@@ -3092,7 +3071,7 @@ Alg_seq *Alg_seq::cut(double start, double len, bool all)
 }
 
 
-void Alg_seq::insert_silence_in_track(int track_num, double t, double len)
+void Alg_seq::insert_silence_in_track(size_t track_num, double t, double len)
 {
     Alg_track *tr = track(track_num);
     tr->insert_silence(t, len);
@@ -3101,7 +3080,7 @@ void Alg_seq::insert_silence_in_track(int track_num, double t, double len)
 
 void Alg_seq::insert_silence(double t, double len)
 {
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         insert_silence_in_track(i, t, len);
     }
     double t_beats = t;
@@ -3123,7 +3102,7 @@ void Alg_seq::insert_silence(double t, double len)
 }
 
 
-Alg_track *Alg_seq::copy_track(int track_num, double t, double len, bool all)
+Alg_track *Alg_seq::copy_track(size_t track_num, double t, double len, bool all)
 {
     return track_list[track_num].copy(t, len, all);
 }
@@ -3149,7 +3128,7 @@ Alg_seq *Alg_seq::copy(double start, double len, bool all)
     result->units_are_seconds = units_are_seconds;
     result->track_list.reset();
 
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         Alg_track *copy = copy_track(i, start, len, all);
         result->track_list.append(copy);
         result->last_note_off = std::max(result->last_note_off,
@@ -3193,7 +3172,7 @@ void Alg_seq::paste(double start, Alg_seq *seq)
     seq->convert_to_beats();
 
     // do a paste on each track
-    int i;
+    size_t i;
     for (i = 0; i < seq->tracks(); i++) {
         if (i >= tracks()) {
             add_track(i);
@@ -3226,7 +3205,7 @@ void Alg_seq::merge(double t, Alg_event_list *seq)
     // seq must be an Alg_seq:
     assert(seq->get_type() == 's');
     Alg_seq *s = (Alg_seq*) seq;
-    for (int i = 0; i < s->tracks(); i++) {
+    for (size_t i = 0; i < s->tracks(); i++) {
         if (tracks() <= i) {
             add_track(i);
         }
@@ -3235,7 +3214,7 @@ void Alg_seq::merge(double t, Alg_event_list *seq)
 }
 
 
-void Alg_seq::silence_track(int track_num, double start, double len, bool all)
+void Alg_seq::silence_track(size_t track_num, double start, double len, bool all)
 {
     // remove events in [time, time + len) and close gap
     Alg_track *tr = track(track_num);
@@ -3245,13 +3224,13 @@ void Alg_seq::silence_track(int track_num, double start, double len, bool all)
 
 void Alg_seq::silence(double t, double len, bool all)
 {
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         silence_track(i, t, len, all);
     }
 }
 
 
-void Alg_seq::clear_track(int track_num, double start, double len, bool all)
+void Alg_seq::clear_track(size_t track_num, double start, double len, bool all)
 {
     // remove events in [time, time + len) and close gap
     Alg_track *tr = track(track_num);
@@ -3272,7 +3251,7 @@ void Alg_seq::clear(double start, double len, bool all)
         len = dur - start;
     }
 
-    for (int i = 0; i < tracks(); i++) {
+    for (size_t i = 0; i < tracks(); i++) {
         clear_track(i, start, len, all);
     }
 
@@ -3295,7 +3274,7 @@ void Alg_seq::clear(double start, double len, bool all)
 }
 
 
-Alg_event_list *Alg_seq::find_in_track(int track_num, double t, double len,
+Alg_event_list *Alg_seq::find_in_track(size_t track_num, double t, double len,
                                           bool all, long channel_mask,
                                           long event_type_mask)
 {
@@ -3305,7 +3284,7 @@ Alg_event_list *Alg_seq::find_in_track(int track_num, double t, double len,
 
 Alg_seq::~Alg_seq()
 {
-    int i, j;
+    size_t i, j;
     // Tracks does not delete Alg_events elements
     for (j = 0; j < track_list.length(); j++) {
         Alg_track &notes = track_list[j];
@@ -3318,10 +3297,10 @@ Alg_seq::~Alg_seq()
 }
 
 
-long Alg_seq::seek_time(double time, int track_num)
+size_t Alg_seq::seek_time(double time, size_t track_num)
 // find index of first score event after time
 {
-    long i;
+    size_t i;
     Alg_events &notes = track_list[track_num];
     for (i = 0; i < notes.length(); i++) {
         if (notes[i]->time > time) {
@@ -3386,7 +3365,7 @@ bool Alg_seq::insert_tempo(double bpm, double beat)
     }
     convert_to_beats(); // beats are invariant when changing tempo
     double time = time_map->beat_to_time(beat);
-    long i = time_map->locate_time(time);
+    size_t i = time_map->locate_time(time);
     if (i >= time_map->beats.len || !within(time_map->beats[i].time, time, 0.000001)) {
         insert_beat(time, beat);
     }
@@ -3413,7 +3392,7 @@ bool Alg_seq::insert_tempo(double bpm, double beat)
 }
 
 
-void Alg_seq::add_event(Alg_event *event, int track_num)
+void Alg_seq::add_event(Alg_event *event, size_t track_num)
     // add_event puts an event in a given track (track_num).
     // The track must exist. The time and duration of the
     // event are interpreted according to whether the Alg_seq
@@ -3473,7 +3452,7 @@ void Alg_seq::beat_to_measure(double beat, long *measure, double *m_beat,
     // return [measure, beat, num, den]
     double m = 0; // measure number
     double bpm;
-    int tsx;
+    size_t tsx;
     bpm = 4;
     // assume 4/4 if no time signature
     double prev_beat = 0;
@@ -3481,7 +3460,7 @@ void Alg_seq::beat_to_measure(double beat, long *measure, double *m_beat,
     double prev_den = 4;
 
     // negative measures treated as zero
-    beat = std::max<double>(beat, 0);
+    beat = std::max(beat, 0.0);
 
     for (tsx = 0; tsx < time_sig.length(); tsx++) {
         if (time_sig[tsx].beat <= beat) {
@@ -3528,8 +3507,7 @@ void Alg_iterator::begin_seq(Alg_seq *s, void *cookie, double offset)
 {
     // keep an array of indexes into tracks
     // printf("new pending\n");
-    int i;
-    for (i = 0; i < s->track_list.length(); i++) {
+    for (size_t i = 0; i < s->track_list.length(); i++) {
         if (s->track_list[i].length() > 0) {
             insert(&(s->track_list[i]), 0, true, cookie, offset);
         }
@@ -3578,7 +3556,7 @@ Alg_event *Alg_iterator::next(bool *note_on, void **cookie_ptr,
 
 void Alg_iterator::request_note_off()
 {
-    assert(index >= 0 && index < events_ptr->length());
+    assert(index < events_ptr->length());
     insert(events_ptr, index, false, cookie, offset);
 }
 
@@ -3591,8 +3569,7 @@ void Alg_iterator::end()
 void Alg_seq::merge_tracks()
 {
     long sum = 0;
-    long i;
-    for (i = 0; i < track_list.length(); i++) {
+    for (size_t i = 0; i < track_list.length(); i++) {
         sum = sum + track(i)->length();
     }
     // preallocate array for efficiency:

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -939,7 +939,7 @@ void Alg_time_map::insert_beat(double time, double beat)
     // make sure we didn't generate a zero tempo.
     // if so, space beats by one microbeat as necessary
     for (
-        size_t j = std::max(1UL, i); // do not adjust beats[0]
+        auto j = std::max(size_t{1}, i); // do not adjust beats[0]
         j < beats.len && beats[j - 1].beat + 0.000001 >= beats[j].beat;
         j++
     ) {
@@ -1407,7 +1407,7 @@ void Serial_write_buffer::check_buffer(size_t needed)
     if (len < (ptr - buffer) + needed) { // do we need more space?
         // initially, length is zero, so bump new_len to a minimum starting value
         // make sure new_len is as big as needed; exponential growth is important
-        size_t new_len = std::max({needed, len * 2, 1024UL});
+        auto new_len = std::max({needed, len * 2, size_t{1024}});
         char *new_buffer = new char[new_len]; // allocate space
         ptr = new_buffer + (ptr - buffer); // relocate ptr to new buffer
         if (len > 0) { // we had a buffer already
@@ -2715,7 +2715,7 @@ void Alg_iterator::show()
 {
     for (size_t i = 0; i < len; i++) {
         Alg_pending_event *p = &(pending_events[i]);
-        printf("    %zu: %p[%ld]@%g on %d\n", i, static_cast<void*>(p->events), p->index,
+        printf("    %zu: %p[%zu]@%g on %d\n", i, static_cast<void*>(p->events), p->index,
                p->offset, p->note_on);
     }
 }

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -1168,7 +1168,7 @@ void Alg_time_map::cut(double start, double len, bool units_are_seconds)
     // now, we're correct up to beats[i] and beats[i] happens at start.
     // find first beat after end so we can start shifting from there
     i = i + 1;
-    int start_index = i;
+    size_t start_index = i;
     while (i < length() && beats[i].time < end + ALG_EPS) {
         i++;
     }
@@ -1509,8 +1509,7 @@ void Alg_track::serialize_parameter(Alg_parameter *parm)
 {
     // add eight to account for name + zero end-of-string and the
     // possibility of adding 7 padding bytes
-    long len = strlen(parm->attr_name()) + 8;
-    ser_write_buf.check_buffer(len);
+    ser_write_buf.check_buffer(strlen(parm->attr_name()) + 8);
     ser_write_buf.set_string(parm->attr_name());
     ser_write_buf.pad();
     switch (parm->attr_type()) {
@@ -2093,7 +2092,7 @@ size_t Alg_time_sigs::find_beat(double beat)
 
 double Alg_time_sigs::get_bar_len(double beat)
 {
-    int i = find_beat(beat);
+    size_t i = find_beat(beat);
     double num = 4.0;
     double den = 4.0;
     if (i != 0) {
@@ -2593,7 +2592,7 @@ Alg_tracks::~Alg_tracks()
 }
 
 
-void Alg_tracks::expand_to(int new_max)
+void Alg_tracks::expand_to(size_t new_max)
 {
     maxlen = new_max;
     Alg_track **new_tracks = new Alg_track*[maxlen];
@@ -2672,7 +2671,7 @@ void Alg_tracks::set_in_use(bool flag)
 }
 
 
-void Alg_iterator::expand_to(int new_max)
+void Alg_iterator::expand_to(size_t new_max)
 {
     maxlen = new_max;
     Alg_pending_event *new_pending_events = new Alg_pending_event[maxlen];
@@ -2749,8 +2748,8 @@ void Alg_iterator::insert(Alg_events *events, size_t index,
                event->get_end_time(), offset);
     }
      * END DEBUG */
-    int loc = len;
-    int loc_parent = HEAP_PARENT(loc);
+    size_t loc = len;
+    size_t loc_parent = HEAP_PARENT(loc);
     len++;
     // sift up:
     while (loc > 0 &&
@@ -3549,7 +3548,7 @@ void Alg_iterator::end()
 
 void Alg_seq::merge_tracks()
 {
-    long sum = 0;
+    size_t sum = 0;
     for (size_t i = 0; i < track_list.length(); i++) {
         sum = sum + track(i)->length();
     }
@@ -3557,7 +3556,7 @@ void Alg_seq::merge_tracks()
     Alg_event **notes = new Alg_event*[sum];
     Alg_iterator iterator(this, false);
     iterator.begin();
-    long notes_index = 0;
+    size_t notes_index = 0;
 
     Alg_event *event;
     while ((event = iterator.next())) {

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -34,7 +34,7 @@ public:
     long parse_int(string &field);
     size_t find_real_in(string &field, size_t n);
     double parse_real(string &field);
-    void parse_error(string &field, long offset, const char *message);
+    void parse_error(string &field, size_t offset, const char *message);
     double parse_dur(string &field, double base);
     double parse_after_dur(double dur, string &field, int n, double base);
     double parse_loud(string &field);
@@ -51,7 +51,7 @@ public:
 double Alg_reader::parse_pitch(string &field)
 {
     if (isdigit(field[1])) {
-        int last = find_real_in(field, 1);
+        size_t last = find_real_in(field, 1);
         string real_string = field.substr(1, last - 1);
         return atof(real_string.c_str());
     } else {
@@ -495,9 +495,9 @@ size_t Alg_reader::find_real_in(string &field, size_t n)
 double Alg_reader::parse_real(string &field)
 {
     const char *msg = "Real expected";
-    int last = find_real_in(field, 1);
+    size_t last = find_real_in(field, 1);
     string real_string = field.substr(1, last - 1);
-    if (last <= 1 || last < static_cast<int>(field.length())) {
+    if (last <= 1 || last < field.length()) {
        parse_error(field, 1, msg);
        return 0;
     }
@@ -505,12 +505,12 @@ double Alg_reader::parse_real(string &field)
 }
 
 
-void Alg_reader::parse_error(string &field, long offset, const char *message)
+void Alg_reader::parse_error(string &field, size_t offset, const char *message)
 {
-    int position = line_parser.pos - field.length() + offset;
+    size_t position = line_parser.pos - field.length() + offset;
     error_flag = true;
     puts(line_parser.str->c_str());
-    for (int i = 0; i < position; i++) {
+    for (size_t i = 0; i < position; i++) {
         putc(' ', stdout);
     }
     putc('^', stdout);
@@ -526,7 +526,7 @@ double Alg_reader::parse_dur(string &field, double base)
     const char *msg = "Duration expected";
     const char *durs = "SIQHW";
     const char *p;
-    int last;
+    size_t last;
     double dur;
     if (field.length() < 2) {
         // fall through to error message
@@ -565,7 +565,7 @@ double Alg_reader::parse_after_dur(double dur, string &field,
         return parse_after_dur(dur * 1.5, field, n + 1, base);
     }
     if (isdigit(field[n])) {
-        int last = find_real_in(field, n);
+        size_t last = find_real_in(field, n);
         string a_string = field.substr(n, last - n);
         double f = atof(a_string.c_str());
         return parse_after_dur(dur * f, field, last, base);

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -32,7 +32,7 @@ public:
     bool parse();
     long parse_chan(string &field);
     long parse_int(string &field);
-    int find_real_in(string &field, int n);
+    size_t find_real_in(string &field, size_t n);
     double parse_real(string &field);
     void parse_error(string &field, long offset, const char *message);
     double parse_dur(string &field, double base);
@@ -43,7 +43,7 @@ public:
     long parse_after_key(int key, string &field, int n);
     long find_int_in(string &field, int n);
     bool parse_attribute(string &field, Alg_parameter *parm);
-    bool parse_val(Alg_parameter *param, string &s, int i);
+    bool parse_val(Alg_parameter *param, string &s, size_t i);
     bool check_type(char type_char, Alg_parameter *param);
 };
 
@@ -472,13 +472,13 @@ long Alg_reader::parse_int(string &field)
 }
 
 
-int Alg_reader::find_real_in(string &field, int n)
+size_t Alg_reader::find_real_in(string &field, size_t n)
 {
     // scans from offset n to the end of a real constant
     bool decimal = false;
-    int len = field.length();
+    size_t len = field.length();
     if (n < len && field[n] == '-') { n++; } // parse one minus sign
-    for (int i = n; i < len; i++) {
+    for (size_t i = n; i < len; i++) {
         char c = field[i];
         if (!isdigit(c)) {
             if (c == '.' && !decimal) {
@@ -686,9 +686,9 @@ bool Alg_reader::parse_attribute(string &field, Alg_parameter *param)
 }
 
 
-bool Alg_reader::parse_val(Alg_parameter *param, string &s, int i)
+bool Alg_reader::parse_val(Alg_parameter *param, string &s, size_t i)
 {
-    int len = static_cast<int>(s.length());
+    size_t len = s.length();
     if (i >= len) {
         return false;
     }
@@ -719,7 +719,7 @@ bool Alg_reader::parse_val(Alg_parameter *param, string &s, int i)
             return false;
         }
     } else if (isdigit(s[i]) || s[i] == '-' || s[i] == '.') {
-        int pos = i;
+        size_t pos = i;
         bool period = false;
         if (s[pos] == '-') { pos++; }
         while (pos < len) {

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -36,7 +36,7 @@ public:
     double parse_real(string &field);
     void parse_error(string &field, size_t offset, const char *message);
     double parse_dur(string &field, double base);
-    double parse_after_dur(double dur, string &field, int n, double base);
+    double parse_after_dur(double dur, string &field, size_t n, double base);
     double parse_loud(string &field);
     long parse_key(string &field);
     double parse_pitch(string &field);
@@ -221,7 +221,7 @@ bool Alg_reader::parse()
                 field.append(field2);
             }
             while (field[0]) {
-                char first = toupper(field[0]);
+                int first = toupper(field[0]);
                 if (strchr("ABCDEFGKLPUSIQHW-", first)) {
                     valid = true; // it's a note or event
                 }
@@ -553,9 +553,9 @@ double Alg_reader::parse_dur(string &field, double base)
 
 
 double Alg_reader::parse_after_dur(double dur, string &field,
-                                   int n, double base)
+                                   size_t n, double base)
 {
-    if (static_cast<int>(field.length()) == n) {
+    if (field.length() == n) {
         return dur;
     }
     if (toupper(field[n]) == 'T') {
@@ -638,7 +638,7 @@ long Alg_reader::parse_after_key(int key, string &field, int n)
     if (static_cast<int>(field.length()) == n) {
         return key;
     }
-    char c = toupper(field[n]);
+    int c = toupper(field[n]);
     if (c == 'S') {
         return parse_after_key(key + 1, field, n + 1);
     }

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -77,17 +77,17 @@ protected:
     void Mf_pitchbend(int,int,int) override;
     void Mf_program(int,int) override;
     void Mf_chanpressure(int,int) override;
-    void binary_msg(int len, unsigned char *msg, const char *attr_string);
-    void Mf_sysex(int,unsigned char*) override;
-    void Mf_arbitrary(int,unsigned char*) override;
+    void binary_msg(size_t len, unsigned char *msg, const char *attr_string);
+    void Mf_sysex(size_t, unsigned char*) override;
+    void Mf_arbitrary(size_t, unsigned char*) override;
     void Mf_metamisc(int,int,unsigned char*) override;
     void Mf_seqnum(int) override;
     void Mf_smpte(int,int,int,int,int) override;
     void Mf_timesig(int,int,int,int) override;
     void Mf_tempo(int) override;
     void Mf_keysig(int,int) override;
-    void Mf_sqspecific(int,unsigned char*) override;
-    void Mf_text(int,int,unsigned char*) override;
+    void Mf_sqspecific(size_t, unsigned char*) override;
+    void Mf_text(int, size_t, unsigned char*) override;
 };
 
 
@@ -314,12 +314,12 @@ void Alg_midifile_reader::Mf_chanpressure(int chan, int val)
 }
 
 
-void Alg_midifile_reader::binary_msg(int len, unsigned char *msg,
+void Alg_midifile_reader::binary_msg(size_t len, unsigned char *msg,
                                      const char *attr_string)
 {
     Alg_parameter parameter;
     char *hexstr = new char[len * 2 + 1];
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
 #if defined(_WIN32)
 #pragma warning(disable: 4996) // hexstr is long enough
 #endif
@@ -334,14 +334,14 @@ void Alg_midifile_reader::binary_msg(int len, unsigned char *msg,
 }
 
 
-void Alg_midifile_reader::Mf_sysex(int len, unsigned char *msg)
+void Alg_midifile_reader::Mf_sysex(size_t len, unsigned char *msg)
 {
     // sysex messages become updates with attribute sysexs and a hex string
     binary_msg(len, msg, "sysexs");
 }
 
 
-void Alg_midifile_reader::Mf_arbitrary(int /*len*/, unsigned char* /*msg*/)
+void Alg_midifile_reader::Mf_arbitrary(size_t /*len*/, unsigned char* /*msg*/)
 {
     Mf_error("arbitrary data ignored");
 }
@@ -426,7 +426,7 @@ void Alg_midifile_reader::Mf_keysig(int key, int mode)
 }
 
 
-void Alg_midifile_reader::Mf_sqspecific(int len, unsigned char *msg)
+void Alg_midifile_reader::Mf_sqspecific(size_t len, unsigned char *msg)
 {
     // sequencer specific messages become updates with attribute sqspecifics
     // and a hex string for the value
@@ -434,7 +434,7 @@ void Alg_midifile_reader::Mf_sqspecific(int len, unsigned char *msg)
 }
 
 
-char *heapify2(int len, unsigned char *s)
+char *heapify2(size_t len, unsigned char *s)
 {
     char *h = new char[len + 1];
     memcpy(h, s, len);
@@ -443,7 +443,7 @@ char *heapify2(int len, unsigned char *s)
 }
 
 
-void Alg_midifile_reader::Mf_text(int type, int len, unsigned char *msg)
+void Alg_midifile_reader::Mf_text(int type, size_t len, unsigned char *msg)
 {
     Alg_parameter text;
     text.s = heapify2(len, msg);

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -80,7 +80,7 @@ protected:
     void binary_msg(size_t len, unsigned char *msg, const char *attr_string);
     void Mf_sysex(size_t, unsigned char*) override;
     void Mf_arbitrary(size_t, unsigned char*) override;
-    void Mf_metamisc(int,int,unsigned char*) override;
+    void Mf_metamisc(int, size_t, unsigned char*) override;
     void Mf_seqnum(int) override;
     void Mf_smpte(int,int,int,int,int) override;
     void Mf_timesig(int,int,int,int) override;
@@ -347,7 +347,7 @@ void Alg_midifile_reader::Mf_arbitrary(size_t /*len*/, unsigned char* /*msg*/)
 }
 
 
-void Alg_midifile_reader::Mf_metamisc(int type, int /*len*/, unsigned char* /*msg*/)
+void Alg_midifile_reader::Mf_metamisc(int type, size_t /*len*/, unsigned char* /*msg*/)
 {
     char text[128];
 #if defined(_WIN32)

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -175,13 +175,7 @@ void Alg_midifile_reader::Mf_header(int format, int /*ntrks*/, int division)
 {
     if (format > 1) {
         char msg[80];
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // msg is long enough
-#endif
         sprintf(msg, "file format %d not implemented", format);
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
         Mf_error(msg);
     }
     divisions = division;
@@ -270,13 +264,7 @@ void Alg_midifile_reader::Mf_controller(int chan, int control, int val)
 {
     Alg_parameter parameter;
     char name[32];
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // name is long enough
-#endif
     sprintf(name, "control%dr", control);
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
     parameter.set_attr(symbol_table.insert_string(name));
     parameter.r = val / 127.0;
     update(chan, -1, &parameter);
@@ -320,13 +308,7 @@ void Alg_midifile_reader::binary_msg(size_t len, unsigned char *msg,
     Alg_parameter parameter;
     char *hexstr = new char[len * 2 + 1];
     for (size_t i = 0; i < len; i++) {
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // hexstr is long enough
-#endif
         sprintf(hexstr + 2 * i, "%02x", (0xFF & msg[i]));
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
     }
     parameter.s = hexstr;
     parameter.set_attr(symbol_table.insert_string(attr_string));
@@ -350,13 +332,7 @@ void Alg_midifile_reader::Mf_arbitrary(size_t /*len*/, unsigned char* /*msg*/)
 void Alg_midifile_reader::Mf_metamisc(int type, size_t /*len*/, unsigned char* /*msg*/)
 {
     char text[128];
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // text is long enough
-#endif
     sprintf(text, "metamsic data, type 0x%x, ignored", type);
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
     Mf_error(text);
 }
 
@@ -377,14 +353,8 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
     char text[32];
     int fps = (hours >> 6) & 3;
     hours &= 0x1F;
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // text is long enough
-#endif
     sprintf(text, "%sfps:%02dh:%02dm:%02ds:%02d.%02df",
             fpsstr[fps], hours, mins, secs, frames, subframes);
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
     Alg_parameter smpteoffset;
     smpteoffset.s = heapify(text);
     smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));

--- a/src/allegrosmfwr.cpp
+++ b/src/allegrosmfwr.cpp
@@ -62,9 +62,9 @@ private:
 
     void write_delta(double event_time);
     void write_varinum(int num);
-    void write_16bit(int num);
-    void write_24bit(int num);
-    void write_32bit(int num);
+    void write_16bit(int16_t num);
+    void write_24bit(int32_t num);
+    void write_32bit(int32_t num);
 };
 
 
@@ -383,11 +383,11 @@ void Alg_smf_write::write_update(Alg_update *update)
         int frames = decimal(s);
         s += 3;
         int subframes = decimal(s);
-        smpteoffset[0] = (fps << 6) + hours;
-        smpteoffset[1] = mins;
-        smpteoffset[2] = secs;
-        smpteoffset[3] = frames;
-        smpteoffset[4] = subframes;
+        smpteoffset[0] = static_cast<char>((fps << 6) + hours);
+        smpteoffset[1] = static_cast<char>(mins);
+        smpteoffset[2] = static_cast<char>(secs);
+        smpteoffset[3] = static_cast<char>(frames);
+        smpteoffset[4] = static_cast<char>(subframes);
         write_smpteoffset(update, smpteoffset);
 // clean up our macro
 #undef decimal
@@ -594,20 +594,20 @@ void Alg_smf_write::write(std::ostream &file)
 }
 
 
-void Alg_smf_write::write_16bit(int num)
+void Alg_smf_write::write_16bit(int16_t num)
 {
     out_file->put((num & 0xFF00) >> 8);
     out_file->put(num & 0xFF);
 }
 
-void Alg_smf_write::write_24bit(int num)
+void Alg_smf_write::write_24bit(int32_t num)
 {
     out_file->put((num & 0xFF0000) >> 16);
     out_file->put((num & 0xFF00) >> 8);
     out_file->put((num & 0xFF));
 }
 
-void Alg_smf_write::write_32bit(int num)
+void Alg_smf_write::write_32bit(int32_t num)
 {
     out_file->put((num & 0xFF000000) >> 24);
     out_file->put((num & 0xFF0000) >> 16);

--- a/src/allegrowr.cpp
+++ b/src/allegrowr.cpp
@@ -61,7 +61,7 @@ Alg_event *Alg_seq::write_track_name(std::ostream &file, int n,
     const char *attr = symbol_table.insert_string(
                                n == 0 ? "seqnames" : "tracknames");
     // search for name in events with timestamp of 0
-    for (int i = 0; i < events.length(); i++) {
+    for (size_t i = 0; i < events.length(); i++) {
         Alg_event *ue = events[i];
         if (ue->time > 0) {
             break;
@@ -82,7 +82,6 @@ Alg_event *Alg_seq::write_track_name(std::ostream &file, int n,
 
 void Alg_seq::write(std::ostream &file, bool in_secs, double offset)
 {
-    int i, j;
     if (in_secs) {
         convert_to_seconds();
     } else {
@@ -91,7 +90,7 @@ void Alg_seq::write(std::ostream &file, bool in_secs, double offset)
     file << "#offset " << offset << std::endl;
     Alg_event *update_to_skip = write_track_name(file, 0, track_list[0]);
     Alg_beats &beats = time_map->beats;
-    for (i = 0; i < beats.len - 1; i++) {
+    for (size_t i = 0; i < beats.len - 1; i++) {
         Alg_beat *b = &(beats[i]);
         if (in_secs) {
             file << "T" << TIMFMT << b->time;
@@ -113,7 +112,7 @@ void Alg_seq::write(std::ostream &file, bool in_secs, double offset)
     }
 
     // write the time signatures
-    for (i = 0; i < time_sig.length(); i++) {
+    for (size_t i = 0; i < time_sig.length(); i++) {
         Alg_time_sig &ts = time_sig[i];
         double time = ts.beat;
         if (in_secs) {
@@ -130,13 +129,13 @@ void Alg_seq::write(std::ostream &file, bool in_secs, double offset)
         }
     }
 
-    for (j = 0; j < track_list.length(); j++) {
+    for (size_t j = 0; j < track_list.length(); j++) {
         Alg_events &notes = track_list[j];
         if (j != 0) {
             update_to_skip = write_track_name(file, j, notes);
         }
         // now write the notes at beat positions
-        for (i = 0; i < notes.length(); i++) {
+        for (size_t i = 0; i < notes.length(); i++) {
             Alg_event *e = notes[i];
             // if we already wrote this event as a track or sequence name,
             // do not write it again

--- a/src/allegrowr.cpp
+++ b/src/allegrowr.cpp
@@ -48,7 +48,7 @@ void parameter_print(std::ostream &file, Alg_parameter *p)
     } /* switch (p->attr_type()) */
 }
 
-Alg_event *Alg_seq::write_track_name(std::ostream &file, int n,
+Alg_event *Alg_seq::write_track_name(std::ostream &file, size_t n,
                                         Alg_events &events)
 // write #track <n> <trackname-or-sequencename>
 // if we write the name on the "#track" line, then we do *not* want

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -467,21 +467,21 @@ int16_t Midifile_reader::to16bit(int8_t c1, int8_t c2)
 
 int32_t Midifile_reader::read32bit()
 {
-    int c1, c2, c3, c4;
+    int8_t c1, c2, c3, c4;
 
-    c1 = egetc();
+    c1 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }
-    c2 = egetc();
+    c2 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }
-    c3 = egetc();
+    c3 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }
-    c4 = egetc();
+    c4 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }
@@ -490,12 +490,12 @@ int32_t Midifile_reader::read32bit()
 
 int16_t Midifile_reader::read16bit()
 {
-    int c1, c2;
-    c1 = egetc();
+    int8_t c1, c2;
+    c1 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }
-    c2 = egetc();
+    c2 = static_cast<int8_t>(egetc());
     if (midifile_error) {
         return 0;
     }

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -319,7 +319,7 @@ void Midifile_reader::badbyte(int c)
 
 void Midifile_reader::metaevent(int type)
 {
-    int leng = msgleng();
+    size_t leng = msgleng();
     // made this unsigned to avoid sign extend
     unsigned char *m = msg();
 
@@ -455,23 +455,17 @@ long Midifile_reader::readvarinum()
     return value;
 }
 
-long Midifile_reader::to32bit(int c1, int c2, int c3, int c4)
+int32_t Midifile_reader::to32bit(int8_t c1, int8_t c2, int8_t c3, int8_t c4)
 {
-    long value = 0L;
-
-    value = (c1 & 0xff);
-    value = (value<<8) + (c2 & 0xff);
-    value = (value<<8) + (c3 & 0xff);
-    value = (value<<8) + (c4 & 0xff);
-    return value;
+    return (c1 << 24) | (c2 << 16) | (c3 << 8) | (c4);
 }
 
-int Midifile_reader::to16bit(int c1, int c2)
+int16_t Midifile_reader::to16bit(int8_t c1, int8_t c2)
 {
-    return ((c1 & 0xff) << 8) + (c2 & 0xff);
+    return (c1 << 8) | (c2);
 }
 
-long Midifile_reader::read32bit()
+int32_t Midifile_reader::read32bit()
 {
     int c1, c2, c3, c4;
 
@@ -494,7 +488,7 @@ long Midifile_reader::read32bit()
     return to32bit(c1, c2, c3, c4);
 }
 
-int Midifile_reader::read16bit()
+int16_t Midifile_reader::read16bit()
 {
     int c1, c2;
     c1 = egetc();
@@ -551,7 +545,7 @@ unsigned char *Midifile_reader::msg()
     return Msgbuff;
 }
 
-int Midifile_reader::msgleng()
+size_t Midifile_reader::msgleng()
 {
     return Msgindex;
 }
@@ -569,7 +563,7 @@ void Midifile_reader::msgenlarge()
 {
     unsigned char *newmess;
     unsigned char *oldmess = Msgbuff;
-    int oldleng = Msgsize;
+    size_t oldleng = Msgsize;
 
     Msgsize += MSGINCREMENT;
     newmess = static_cast<unsigned char *>(Mf_malloc((sizeof(unsigned char) * Msgsize)));

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -73,14 +73,8 @@ int Midifile_reader::readmt(const char *s, int skip)
         goto retry;
     }
     err:
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // strcpy is safe since strings have known lengths
-#endif
     (void) strcpy(buff, errmsg);
     (void) strcat(buff, s);
-#if defined(_WIN32)
-#pragma warning(default: 4996) // turn it back on
-#endif
     mferror(buff);
     return(0);
 }
@@ -307,13 +301,7 @@ void Midifile_reader::readtrack()
 void Midifile_reader::badbyte(int c)
 {
     char buff[32];
-#if defined(_WIN32)
-#pragma warning(disable: 4996) // safe in this case
-#endif
     (void) sprintf(buff,"unexpected byte: 0x%02x",c);
-#if defined(_WIN32)
-#pragma warning(default: 4996)
-#endif
     mferror(buff);
 }
 

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -57,7 +57,7 @@ int Midifile_reader::readmt(const char *s, int skip)
             errmsg = "EOF while expecting ";
             goto err;
         }
-        b[nread++] = c;
+        b[nread++] = static_cast<char>(c);
     }
     /* See if we found the 4 characters we're looking for */
     if (s[0] == b[0] && s[1] == b[1] && s[2] == b[2] && s[3] == b[3]) {
@@ -222,7 +222,7 @@ void Midifile_reader::readtrack()
             msginit();
 
             while (Mf_toberead > lookfor) {
-                unsigned char c = egetc();
+                c = egetc();
                 if (midifile_error) {
                     return;
                 }

--- a/src/strparse.cpp
+++ b/src/strparse.cpp
@@ -53,11 +53,11 @@ static const char *const escape_chars[] = {"\\n", "\\t", "\\\\", "\\r", "\\\""};
 
 void string_escape(std::string &result, const char *str, const char *quote)
 {
-    int length = static_cast<int>(strlen(str));
     if (quote[0]) {
         result.append(1, quote[0]);
     }
-    for (int i = 0; i < length; i++) {
+    size_t length = strlen(str);
+    for (size_t i = 0; i < length; i++) {
         if (!isalnum(static_cast<unsigned char>(str[i]))) {
             const char *const chars = "\n\t\\\r\"";
             const char *const special = strchr(chars, str[i]);
@@ -77,7 +77,7 @@ void String_parse::get_remainder(std::string &field)
 {
     field.clear();
     skip_space();
-    int len = str->length() - pos;
+    ptrdiff_t len = str->length() - pos;
     if ((len > 0) && ((*str)[len - 1] == '\n')) { // if str ends in newline,
         len--; // reduce length to ignore newline
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,9 +5,9 @@ using namespace std;
 
 void seq_print(Alg_seq *seq)
 {
-    for (int i = 0; i < seq->tracks(); i++) {
-        printf("TRACK %d\n", i);
-        for (int j = 0; j < seq->track(i)->length(); j++) {
+    for (size_t i = 0; i < seq->tracks(); i++) {
+        printf("TRACK %zu\n", i);
+        for (size_t j = 0; j < seq->track(i)->length(); j++) {
             (*seq->track(i))[j]->show();
         }
     }
@@ -139,9 +139,9 @@ void test6()
 {
     Alg_seq *seq = make_score();
     seq->write(cout, true);
-	long index = seq->seek_time(1.0, 0);
+	size_t index = seq->seek_time(1.0, 0);
 	printf("seq->get_units_are_seconds() = %d\n", seq->get_units_are_seconds());
-	printf("seq->seek_time(1.0, 0) returns %ld\n", index);
+	printf("seq->seek_time(1.0, 0) returns %zu\n", index);
 	printf("note is:\n");
 	if ((*seq->track(0))[index]->is_note()) {
 		((Alg_note*) (*(seq->track(0)))[index])->show();
@@ -717,7 +717,7 @@ void test32() // serialize big midi file and unserialize
     ofile.close();
 
     void *buffer;
-    long bytes;
+    size_t bytes;
     seq->serialize(&buffer, &bytes);
     printf("Serialized %ld bytes\n", bytes);
     Alg_seq *new_seq = (Alg_seq*) seq->unserialize(buffer, bytes);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -719,7 +719,7 @@ void test32() // serialize big midi file and unserialize
     void *buffer;
     size_t bytes;
     seq->serialize(&buffer, &bytes);
-    printf("Serialized %ld bytes\n", bytes);
+    printf("Serialized %zu bytes\n", bytes);
     Alg_seq *new_seq = (Alg_seq*) seq->unserialize(buffer, bytes);
     ofstream sfile("bigseq2.alg", ios::out | ios::binary);
     new_seq->write(sfile, true);


### PR DESCRIPTION
Resolves #4:

- Changes `int` to `int16_t` for variables intended to hold exactly 16 bits
- Changes `long` to `int32_t` for variables intended to hold exactly 32 bits
- Changes `int` and `long` to `size_t` for variables intended to hold an array length or index
- Changes `long` to `ptrdiff_t` for variables intended to hold a difference between pointers or a potentially negative array offset
- Changes format specifiers accordingly (`%zu` is used for `size_t`)

**This changes the public API and should be considered a breaking change.**

Other things that this PR changes:
- Any `for` loops that were already modified by this PR have been updated to declare their variables inline, rather than at the top of the function
- A few `while` loops that were already modified by this PR have been updated to be `for` loops
- Several bounds-checking assertions no longer check for negative indicies (such indicies will underflow to values greater than the array's size, which will still cause the assertion to fail properly)
- `#pragma warning(disable: XXXX)` have been removed by either fixing the underlying problem or by changing build parameters.