### PR TITLE
clang-tidy: modernize-use-equals-default (missed one!)

### DIFF
--- a/include/allegro.h
+++ b/include/allegro.h
@@ -560,7 +560,7 @@ public:
     //! setting buffer, but it is not the Serial_read_buffer's responsibility
     //! to delete the buffer (owner might want to reuse it), so the destructor
     //! does nothing.
-    ~Serial_read_buffer() override { }
+    ~Serial_read_buffer() override = default;
     void get_pad() {
         while (reinterpret_cast<uintptr_t>(ptr) & 7) { ptr++; }
     }


### PR DESCRIPTION
In commit 9d0d0f64987bed24257b8de3c82cb3af346e2bab I changed empty destructor bodies to `= default`, but it appears I missed a single instance of this.